### PR TITLE
Trainings data as YAML, filtered to display only future ones

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 # For more see: https://github.com/mojombo/jekyll/wiki/Permalinks
 permalink: /:categories/:year/:month/:day/:title
 
-exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md", "blog.cmd"]
+exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md", "blog.sh"]
 pygments: true
 markdown: kramdown
 encoding: utf-8
@@ -151,25 +151,3 @@ JB :
   # and include your custom code. Your custom file must be defined at:
   #   ./_includes/custom/[HELPER]
   # where [HELPER] is the name of the helper you are overriding.
-
-  trainings :
-    java-advanced:
-      title: Java avancé
-      location: Lyon
-      dates: 15-17 Avril
-    play:
-      title: Play!
-      location: Lyon
-      dates: 18-20 Juin
-    java8:
-      title: Java 8
-      location: Lyon
-      dates: 19 Juin
-    angularjs:
-      title: AngularJS
-      location: Lyon
-      dates: 5-7 Août
-    git:
-      title: Git
-      location: Lyon
-      dates: 12-13 Août

--- a/_data/trainings.yml
+++ b/_data/trainings.yml
@@ -1,0 +1,29 @@
+- name: git
+  title: Git
+  begin: 2014-08-12
+  end: 2014-08-13
+  location: Lyon
+
+- name: angularjs
+  title: AngularJS
+  begin: 2014-08-05
+  end: 2014-08-07
+  location: Lyon
+
+- name: java8
+  title: Java 8
+  begin: 2014-06-19
+  end: 2014-06-19
+  location: Lyon
+
+- name: javaAdvanced
+  title: Java advanced
+  begin: 2014-04-15
+  end: 2014-04-17
+  location: Lyon
+
+- name: play
+  title: Play!
+  begin: 2014-06-18
+  end: 2014-06-20
+  location: Lyon

--- a/_includes/ninjasquad/trainings
+++ b/_includes/ninjasquad/trainings
@@ -1,5 +1,9 @@
+{% assign nowunix = site.time | date: "%s" %}
 <h4>Formations</h4>
-{% for training in site.JB.trainings %}
-<a href="http://ninja-squad.fr/training/{{training[0]}}">{{training[1].title}}</a>
-<p>{{training[1].dates}}, {{training[1].location}}</p>
+{% for training in site.data.trainings %}
+{% assign beginunix = training.begin | date: "%s" %}
+{% if beginunix > nowunix %}
+<a href="http://ninja-squad.fr/training/{{ training.name }}">{{ training.title }}</a>
+<p>{{ training.begin | date: "%-d %b" }} - {{ training.end | date: "%-d %b" }}, {{ training.location }}</p>
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
Caveats :
- despite what being said on [official documentation](http://jekyllrb.com/docs/datafiles/), Jekyll can't load JSON data. I wanted to reuse `trainings.json` from www, but that's not possible.
- even if only future trainings are displayed, that's only true at generate time (i.e. git push time), not at HTTP request time : if a training is in two days when blog is deployed, it will still be displayed in three days.
- there is still work to have French localized dates, but [that's possible](http://alanwsmith.com/jekyll-liquid-date-formatting-examples)