### PR TITLE
fix: incorrect sample for arrow functions in es6 post

### DIFF
--- a/_posts/2015-10-13-es6-part-2.md
+++ b/_posts/2015-10-13-es6-part-2.md
@@ -238,12 +238,11 @@ But there is now an even more elegant solution with the arrow function syntax:
     let maxFinder = {
       max: 0,
       find: function(numbers) {
-        numbers.forEach(
-          function(element) {
-            if (element > this.max) {
-              this.max = element;
-            }
-          }, this);
+        numbers.forEach(element => {
+          if (element > this.max) {
+            this.max = element;
+          }
+        });
       }
     };
 


### PR DESCRIPTION
spotted by gerald
https://twitter.com/gerald_quintana/status/654339933751123968

Fixed in the book also.

I merge immediatly.