### PR TITLE
chore(jekyll): jekyll 3 compliance

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,6 @@
 permalink: /:categories/:year/:month/:day/:title
 
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md", "blog.cmd"]
-highlighter: pygments
 markdown: kramdown
 encoding: utf-8
 
@@ -169,4 +168,4 @@ JB :
     java8:
       title: Java 8
       dates:
-        - 2 mai à Lyon 
+        - 2 mai à Lyon

--- a/blog.sh
+++ b/blog.sh
@@ -1,3 +1,3 @@
 # this starts jekyll as documented in https://help.github.com/articles/using-jekyll-with-pages
 
-bundle exec Jekyll serve --watch
+bundle exec Jekyll serve --watch --future


### PR DESCRIPTION
Using http://jekyllrb.com/docs/upgrading/2-to-3/ as migration guide.