### PR TITLE
fix(permalink): explicitly define URL of specific pages

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -3,6 +3,7 @@ layout: page
 title : Les archives
 header : Archives
 group: navigation
+permalink: /archive.html
 ---
 {% include JB/setup %}
 

--- a/categories.html
+++ b/categories.html
@@ -2,6 +2,7 @@
 layout: page
 title: Categories
 header: Posts By Category
+permalink: /categories.html
 ---
 {% include JB/setup %}
 
@@ -11,11 +12,10 @@ header: Posts By Category
 </ul>
 
 
-{% for category in site.categories %} 
+{% for category in site.categories %}
   <h2 id="{{ category[0] }}-ref">{{ category[0] | join: "/" }}</h2>
   <ul>
-    {% assign pages_list = category[1] %}  
+    {% assign pages_list = category[1] %}
     {% include JB/pages_list %}
   </ul>
 {% endfor %}
-

--- a/pages.html
+++ b/pages.html
@@ -1,7 +1,8 @@
 ---
 layout: page
-title: Pages 
+title: Pages
 header: Pages
+permalink: /pages.html
 ---
 {% include JB/setup %}
 

--- a/tags.html
+++ b/tags.html
@@ -3,6 +3,7 @@ layout: page
 title: Les catégories
 header: Posts By Tag
 group: navigation
+permalink: /tags.html
 ---
 {% include JB/setup %}
 


### PR DESCRIPTION
Without this, running the blog locally, we had `/archive.html` and `/tags.html` served as valid URL. But in prod, only `/archive` and `tags` are valid URL (which is what is supposed to happen with our current "permalink" config).

So I define with this PR explicit URL for each of specific page, suffixed by ".html", as they are referenced in all our HTML.