### PR TITLE
chore(seo): use jekyll-seo-tag jekyll plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages'
+gem 'jekyll-seo-tag'

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 # For more see: https://github.com/mojombo/jekyll/wiki/Permalinks
 permalink: /:categories/:year/:month/:day/:title/
 
-exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md", "blog.cmd"]
+exclude: [".rvmrc", ".rbenv-version", "README.md", "CNAME", "Rakefile", "changelog.md", "blog.sh", "serve.sh"]
 markdown: kramdown
 encoding: utf-8
 
@@ -16,6 +16,7 @@ twitter: NinjaSquad
 author:
   name: Ninja Squad
   email: contact@ninja-squad.com
+  twitter: NinjaSquad
 authors:
   acrepet:
     name : Agnès Crépet
@@ -42,6 +43,16 @@ authors:
     twitter : jbnizet
     gravatar : 2f0d9dec16bae1e06552af55ddefc11f
     gplus : 113219978281208960764
+
+# SEO
+gems:
+  - jekyll-seo-tag
+
+logo: /assets/images/logo-flat-600.png
+twitter:
+  username: NinjaSquad
+facebook:
+  publisher: ninjasquadfr
 
 
 # The production_url is only used when full-domain names are needed

--- a/_includes/ninjasquad/followus
+++ b/_includes/ninjasquad/followus
@@ -1,5 +1,5 @@
 <h4>Suivez-nous</h4>
 <ul class="nav nav-list">
-	<li><a href="https://twitter.com/{{ site.twitter }}" title="Ninja Squad sur Twitter">Sur Twitter</a></li>
+	<li><a href="https://twitter.com/{{ twitter }}" title="Ninja Squad sur Twitter">Sur Twitter</a></li>
 	<li><a href="https://plus.google.com/{{site.gplus}}" rel="publisher" title="Ninja Squad sur Google+">Sur Google+</a></li>
 </ul>

--- a/_includes/themes/twitter/default.html
+++ b/_includes/themes/twitter/default.html
@@ -2,24 +2,15 @@
 <html lang="fr">
   <head>
     <meta charset="utf-8">
-    <title>Ninja Squad - {{ page.title }}</title>
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ page.title }}">
-{% if page.description %}
-    <meta name="description" content="{{ page.description }}">
-    <meta name="twitter:description" content="{{ page.description }}">
-{% endif %}
 {% if page.canonical %}
     <link rel="canonical" href="{{ page.canonical }}" />
 {% endif %}
     <meta name="author" content="Ninja Squad">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="publisher" href="https://plus.google.com/{{site.gplus}}">
-    <meta name="twitter:site" content="@{{ site.twitter }}">
 {% for auth in page.author %}
   {% assign author = site.authors[auth] %}
     <link rel="author" href="https://plus.google.com/{{author.gplus}}" />
-    <meta name="twitter:creator" content="@{{ author.twitter }}">
 {% endfor %}
 
 
@@ -42,6 +33,8 @@
     <link rel="apple-touch-icon" sizes="114x114" href="/assets/images/apple-touch-icon-114x114.png">
 
     <script src="{{ ASSET_PATH }}/js/jquery-1.7.2.min.js"></script>
+
+    {% seo %}
   </head>
 
   <body>


### PR DESCRIPTION
Use `jekyll-seo-tag` plugin, see https://help.github.com/articles/search-engine-optimization-for-github-pages/, [as suggested](https://ninjasquad.slack.com/archives/general/p1462942070547438) by @cexbrayat.