### PR TITLE
fix(jekyll): change for Jekyll 3.1

### DIFF
--- a/_includes/JB/setup
+++ b/_includes/JB/setup
@@ -16,7 +16,7 @@
     {% if site.JB.ASSET_PATH %}
       {% assign ASSET_PATH = site.JB.ASSET_PATH %}
     {% else %}
-      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ page.theme.name }}{% endcapture %}
-    {% endif %}  
+      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ layout.theme.name }}{% endcapture %}
+    {% endif %}
   {% endif %}
 {% endcapture %}{% assign jbcache = nil %}


### PR DESCRIPTION
A seen in https://github.com/blog/2172-github-pages-now-runs-jekyll-3-1.
Fix #188.

Not sure if it's nice or not, but it worked before and after, without visible changes...