### PR TITLE
fix formatting of interpolations

### DIFF
--- a/_posts/2016-11-17-what-is-new-angular-2.2.md
+++ b/_posts/2016-11-17-what-is-new-angular-2.2.md
@@ -44,9 +44,11 @@ The Router Module offers a very handy directive called `RouterLinkActive`,
 allowing us to add a specific class if a link is active.
 This directive is now exported, and can be used in our templates via a local variable:
 
+    {% raw %}
     <a routerLink="/races/1" routerLinkActive #route="routerLinkActive">
      Race 1 {{ route.isActive ? '(here)' : ''}}
     </a>
+    {% endraw %}
 
 That's all for this small release.
 Check out our [ebook](https://books.ninja-squad.com) and [Pro Pack](https://angular-exercises.ninja-squad.com/) if you want to learn more about Angular!

--- a/_posts/2017-03-24-what-is-new-angular-4.md
+++ b/_posts/2017-03-24-what-is-new-angular-4.md
@@ -97,29 +97,29 @@ to use it in the element.
 
 It can be useful to store a sliced collection for example:
 
-{% raw %}
+    {% raw %}
     <div *ngFor="let pony of ponies | slice:0:2 as total; index as = i">
       {{i+1}}/{{total.length}}: {{pony.name}}
     </div>
-{% endraw %}
+    {% endraw %}
 
 Or even more useful, to subscribe only once to a pipe with `async`. If `race` is an observable, instead of the bad and ugly:
 
-{% raw %}
+    {% raw %}
     <div>
       <h2>{{ (race | async)?.name }}</h2>
       <small>{{ (race | async)?.date }}</small>
     </div>
-{% endraw %}
+    {% endraw %}
 
 you can now use the good:
 
-{% raw %}
+    {% raw %}
     <div *ngIf="race | async as raceModel">
       <h2>{{ raceModel.name }}</h2>
       <small>{{ raceModel.date }}</small>
     </div>
-{% endraw %}
+    {% endraw %}
 
 # Pipes
 
@@ -128,10 +128,10 @@ you can now use the good:
 Angular 4 introduced a new `titlecase` pipe.
 It changes the first letter of each word into uppercase:
 
-{% raw %}
+    {% raw %}
     <p>{{ 'ninja squad' | titlecase }}</p>
     <!-- will display 'Ninja Squad' -->
-{% endraw %}
+    {% endraw %}
 
 # Http
 
@@ -149,17 +149,17 @@ Previously, you had to do:
 
 Overriding a template in a test has also been simplified:
 
-{% raw %}
+    {% raw %}
     TestBed.overrideTemplate(RaceComponent, '<h2>{{race.name}}</h2>');
-{% endraw %}
+    {% endraw %}
 
 Previously, you had to do:
 
-{% raw %}
+    {% raw %}
     TestBed.overrideComponent(RaceComponent, {
       set: { template: '<h2>{{race.name}}</h2>' }
     });
-{% endraw %}
+    {% endraw %}
 
 # Service
 
@@ -190,6 +190,7 @@ One new validator joins the existing `required`, `minLength`, `maxLength` and `p
 
 A new directive has been added to help you compare options from a select: `compareWith`.
 
+    {% raw %}
     <select [compareWith]="byId" [(ngModel)]="selectedPony">
        <option *ngFor="let pony of race.ponies" [ngValue]="pony">{{pony.name}}</option>
     </select>
@@ -197,6 +198,7 @@ A new directive has been added to help you compare options from a select: `compa
     byId(p1: PonyModel, p2: PonyModel) {
        return p1.id === p2.id;
     }
+    {% endraw %}
 
 # Router
 


### PR DESCRIPTION
add missing raw tags. There's still a warning when the blog builds, on an old (2013) article, but the raw tag is already there, and it renders fine...