### PR TITLE
style: change code color

### DIFF
--- a/assets/themes/twitter/css/style.css
+++ b/assets/themes/twitter/css/style.css
@@ -134,6 +134,7 @@ pre, code {
 
 p code {
     font-size: 18px;
+    color: #555555
 }
 
 blockquote p {


### PR DESCRIPTION
I'm tired of the flashing red for code on the blog: what do you think of a more smooth grey color?

Before:
<img width="749" alt="capture d ecran 2017-10-03 a 11 54 26" src="https://user-images.githubusercontent.com/411874/31131842-a7debf24-a831-11e7-8c96-9fd36b99f9a7.png">

After:
<img width="745" alt="capture d ecran 2017-10-03 a 11 54 00" src="https://user-images.githubusercontent.com/411874/31131843-a7e55582-a831-11e7-80ca-2b95acbdc8f8.png">

