### PR TITLE
fix: remove blog warnings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,7 @@ authors:
     gplus : 113219978281208960764
 
 # SEO
-gems:
+plugins:
   - jekyll-seo-tag
 
 logo: /assets/images/logo-flat-600.png

--- a/_posts/2013-06-28-angular-filter-part-1.md
+++ b/_posts/2013-06-28-angular-filter-part-1.md
@@ -101,7 +101,7 @@ Un certain nombre de patterns sont disponibles (avec un rendu différent selon l
 </pre>
 {% endraw %}    
 
-- json : moins connu, ce filtre permet d'afficher l'objet au format JSON. Il est également moins utile, car, par défaut, afficher un object avec la notation '{{ }}' convertit l'objet en JSON.
+- json : moins connu, ce filtre permet d'afficher l'objet au format JSON. Il est également moins utile, car, par défaut, afficher un object avec la notation {% raw %}`{{ }}`{% endraw %} convertit l'objet en JSON.
 {% raw %}
 <pre>
   <code class="javascript">


### PR DESCRIPTION
gems has been renamed plugins
one {{ }} was not escaped in an old blog post