### PR TITLE
chore(https): change production_url to https (for sitemap, notably)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,7 +63,7 @@ facebook:
 # Else if you are pushing to username.github.com, replace with your username.
 # Finally if you are pushing to a GitHub project page, include the project name at the end.
 #
-production_url : http://blog.ninja-squad.com
+production_url : https://blog.ninja-squad.com
 
 # All Jekyll-Bootstrap specific configurations are namespaced into this hash
 #


### PR DESCRIPTION
This will change absolute urls given in `sitemap.txt`, from `http:` to `https:`.
I was afraid to change `production_url` variable, because it is used as site id for Disqus.
But, fortunately, this does not break existing comments: they are still displayed, at least locally.