### PR TITLE
fix: horizontal scroll bar on mobile

### DIFF
--- a/_includes/themes/twitter/page.html
+++ b/_includes/themes/twitter/page.html
@@ -1,8 +1,10 @@
 <div class="page-header">
-  <div style="text-align: center">
-    <a href="/" title="retour à l'accueil">
-  	   <img src="/assets/images/logo-flat-600.png" title="Logo Ninja Squad" alt="Ninja Squad" width="300px" />
-    </a>
+  <div class="row justify-content-center">
+    <div class="col-lg-4 col-md-6 col-8">
+      <a href="/" title="retour à l'accueil">
+        <img src="/assets/images/logo-flat-600.png" class="img-fluid" title="Logo Ninja Squad" alt="Ninja Squad"/>
+      </a>
+    </div>
   </div>
   <h1>{{ page.title }}</h1>
   {% if page.tagline %} <p>{{ page.tagline }}</p>{% endif %}

--- a/assets/themes/twitter/css/style.css
+++ b/assets/themes/twitter/css/style.css
@@ -22,7 +22,7 @@ a:hover, a.page-link:hover {
 
 .content {
   padding: 20px;
-  margin: 0 -20px; /* negative indent the amount of the padding to maintain the grid system */
+  margin: 0 -10px; /* negative indent the amount of the padding to maintain the grid system */
 }
 
 .post-title {
@@ -100,6 +100,7 @@ pre, code {
   line-height: 1.3rem;
   text-align: left;
   word-spacing: normal;
+  word-wrap: break-word;
   color: #555555;
 }
 


### PR DESCRIPTION
It appears that:
- some long code in text like `schematics @angular/schematics` was not split and was overflowing. Fixed with `word-wrap: break-word`;
- there was a weird margin/padding thing that did not compensate each other. Fixed by tweaking the negative margin.
- the home image had a fixed width. Fixed with a responsive image (1/3 of the content in large screen, 1/2 in medium, and 2/3 in small).

I don't understand what are the "too close clickable elements", if anyone has an idea...