### PR TITLE
fix: useId prefix change

### DIFF
--- a/_posts/2024-09-05-what-is-new-vue-3.5.md
+++ b/_posts/2024-09-05-what-is-new-vue-3.5.md
@@ -125,7 +125,7 @@ const id = useId();
 ```
 
 `useId` guarantees that the generated ID is unique within the application.
-By default, Vue generates an ID with a prefix of `v:` followed by a unique number
+By default, Vue generates an ID with a prefix of `v-` followed by a unique number
 (that increments when new components are rendered).
 The prefix can be customized by using `app.config.idPrefix`.
 `useId` also guarantees that the ID is stable between server-side rendering and client-side rendering, to avoid mismatching errors.


### PR DESCRIPTION
The prefix changed in v3.5.3 https://github.com/vuejs/core/commit/babfb4cbcbf98601d76c1d7653eae8d250ce2710